### PR TITLE
Correction of the error "The scheme '' is not supported."

### DIFF
--- a/config/filament-ptbr-form-fields.php
+++ b/config/filament-ptbr-form-fields.php
@@ -1,3 +1,5 @@
 <?php
 
-return [];
+return [
+    'viacep_url' => env('VIACEP_URL', 'viacep.com.br/ws/'),
+];

--- a/src/Cep.php
+++ b/src/Cep.php
@@ -19,7 +19,7 @@ class Cep extends TextInput
 
             $livewire->validateOnly($component->getKey());
 
-            $request = Http::get("viacep.com.br/ws/$state/json/")->json();
+            $request = Http::get(config("filament-ptbr-form-fields.viacep_url") . $state."/json/")->json();
 
             foreach ($setFields as $key => $value) {
                 $set($key, $request[$value] ?? null);


### PR DESCRIPTION
In PHP 8.3 and Laravel 10.38 for some reason, it is necessary to use "Https" or "Http" in the URL of ViaCEP.


![image](https://github.com/leandrocfe/filament-ptbr-form-fields/assets/19355609/a8509be6-8899-47c6-a02e-8ae91874aced)

