### PR TITLE
fix: resolve livewire class resolution issue in tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Leandrocfe\FilamentPtbrFormFields\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Leandrocfe\FilamentPtbrFormFields\FilamentPtbrFormFieldsServiceProvider;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -21,6 +22,7 @@ class TestCase extends Orchestra
     {
         return [
             FilamentPtbrFormFieldsServiceProvider::class,
+            LivewireServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
Resolves the "Target class [livewire] does not exist" error during tests by ensuring the Livewire service provider is included in the test environment setup. This change ensures that Livewire components are correctly registered for testing purposes.

- Added `LivewireServiceProvider::class` to the `getPackageProviders` method in the test case setup.