### PR TITLE
fix: update PHPUnit XML configuration to current schema

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,36 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-    backupGlobals="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    executionOrder="random"
-    failOnWarning="true"
-    failOnRisky="true"
-    failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    cacheDirectory=".phpunit.cache"
-    backupStaticProperties="false"
->
-    <testsuites>
-        <testsuite name="Leandrocfe Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+	<testsuites>
+		<testsuite name="Leandrocfe Test Suite">
+			<directory>
+				tests
+			</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<report>
+			<html outputDirectory="build/coverage" />
+			<text outputFile="build/coverage.txt" />
+			<clover outputFile="build/logs/clover.xml" />
+		</report>
+	</coverage>
+	<logging>
+		<junit outputFile="build/report.junit.xml" />
+	</logging>
+	<source>
+		<include>
+			<directory suffix=".php">
+				./src
+			</directory>
+		</include>
+	</source>
 </phpunit>


### PR DESCRIPTION
This commit updates the PHPUnit XML configuration file to comply with the current schema, resolving the warning about the deprecated schema. The update was performed by running the "--migrate-configuration" option with the PHPUnit command.

- Executed `php ./vendor/bin/pest --migrate-configuration` to migrate the configuration to the current schema.