### PR TITLE
Prevenir validação se o campo for null CEP

### DIFF
--- a/src/Cep.php
+++ b/src/Cep.php
@@ -36,7 +36,9 @@ class Cep extends TextInput
             ->minLength(9)
             ->mask('99999-999')
             ->afterStateUpdated(function ($state, Livewire $livewire, Set $set, Component $component) use ($errorMessage, $setFields, $viaCepRequest) {
-                $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
+                if (!is_null($state)) {
+                    $viaCepRequest($state, $livewire, $set, $component, $errorMessage, $setFields);
+                }
             })
             ->suffixAction(function () use ($mode, $errorMessage, $setFields, $viaCepRequest) {
                 if ($mode === 'suffix') {


### PR DESCRIPTION
Quando usamos outros campos reativos, por por algum motivo o estado acaba sendo enviado como null caso o campo esteja em branco.