### PR TITLE
Fix monetary value conversion in sanitizeState method to avoid errors

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -50,7 +50,7 @@ class Money extends TextInput
 
     protected function hydrateCurrency($state): string
     {
-        $sanitized = $this->sanitizeState($state);
+        $sanitized = $this->sanitizeHydrateState($state);
 
         $money = money(amount: $sanitized, currency: $this->getCurrency());
 
@@ -59,7 +59,7 @@ class Money extends TextInput
 
     protected function dehydrateCurrency($state): int|float|string
     {
-        $sanitized = $this->sanitizeState($state);
+        $sanitized = $this->sanitizeDehydrateState($state);
         $money = money(amount: $sanitized, currency: $this->getCurrency());
 
         if ($this->getDehydrateMask()) {
@@ -83,7 +83,27 @@ class Money extends TextInput
         return $this;
     }
 
-    protected function sanitizeState(?string $state): ?int
+    protected function sanitizeHydrateState(?string $state): ?int
+    {
+        if ($state === null) {
+            return null;
+        }
+
+        $state = trim($state);
+
+        $state = Str::of($state)
+            ->replace(',', '.')
+            ->toString();
+
+        $value = (float) $state;
+
+        if (!$this->getIntFormat()) {
+            $value *= 100;
+        }
+        return (int) round($value);
+    }
+
+    protected function sanitizeDehydrateState(?string $state): ?int
     {
         $state = Str::of($state)
             ->replace('.', '')


### PR DESCRIPTION
This pull request addresses an issue in the sanitizeState method where decimal monetary values were incorrectly converted. For example:

A value of 10.50 would incorrectly convert to 105 instead of 1050.
Changes include:

Adjusting the conversion logic to handle decimal values properly.
Adding support for an intFormat option to skip multiplication by 100 when necessary.
This ensures consistent and accurate conversions, improving compatibility with the Money library.