### PR TITLE
Attempt to correct incorrect float money format

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -50,6 +50,16 @@ class Money extends TextInput
 
     protected function hydrateCurrency($state): string
     {
+        if (! $this->getIntFormat()) {
+            $string = Str::of($state);
+
+            $decimals = $string->contains('.') ? strlen($string->after('.')) : 0;
+
+            if ($decimals < $this->getCurrency()->mathDecimals()) {
+                $state = $state * pow(10, $this->getCurrency()->mathDecimals());
+            }
+        }
+        
         $sanitized = $this->sanitizeState($state);
 
         $money = money(amount: $sanitized, currency: $this->getCurrency());


### PR DESCRIPTION
This commit tries to fix the problem when saved value decimals does not align with the maximum decimals configured.