### PR TITLE
Remove illuminate/contracts dep and add Laravel 13.x compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "php": "^8.2 || ^8.3",
         "archtechx/money": "^0.5.1",
         "filament/filament": "^5.0",
-        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
-        "laravellegends/pt-br-validator": "^10.0 || ^11.0 || ^12.0",
+        "laravellegends/pt-br-validator": "^10.0 || ^11.0 || ^12.0 || ^13.0",
         "moneyphp/money": "^4.5",
         "spatie/laravel-package-tools": "^1.14.0"
     },


### PR DESCRIPTION
## Summary
- Removed `illuminate/contracts` from `require` — Filament already depends on it, so it's redundant.
- Added `^13.0` to `laravellegends/pt-br-validator` constraint to prepare for Laravel 13.x compatibility.

> **Note:** `laravellegends/pt-br-validator` has not yet released a version supporting Laravel 13.x. This change prepares the constraint so it resolves automatically once they do.