### PR TITLE
Suporte ao novo CNPJ alfanumérico

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Document::make('cpf')
 ```
 
 ```php
-//CNPJ
+//CNPJ (accepts the new alphanumeric CNPJ format)
 Document::make('cnpj')
     ->cnpj()
 ```

--- a/src/Concerns/HasCepModes.php
+++ b/src/Concerns/HasCepModes.php
@@ -6,6 +6,7 @@ use Filament\Actions\Action;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Collection;
 use Leandrocfe\FilamentPtbrFormFields\CepFieldMode;
 use Leandrocfe\FilamentPtbrFormFields\Providers\CepProviderInterface;
 use Livewire\Component;
@@ -73,7 +74,7 @@ trait HasCepModes
             });
     }
 
-    protected function fetchCepData(?string $cep, CepProviderInterface $provider): null|array|\Illuminate\Support\Collection
+    protected function fetchCepData(?string $cep, CepProviderInterface $provider): null|array|Collection
     {
         if (blank($cep)) {
             return null;

--- a/src/Document.php
+++ b/src/Document.php
@@ -18,7 +18,7 @@ class Document extends TextInput
 
         if ($condition) {
             $this->mask(RawJs::make(<<<'JS'
-                $input.length > 14 ? '99.999.999/9999-99' : '999.999.999-99'
+                /[A-Za-z]/.test($input) || $input.replace(/[^A-Za-z0-9]/g, '').length > 11 ? '**.***.***/****-99' : '999.999.999-99'
             JS))->minLength(14);
         }
 
@@ -37,7 +37,7 @@ class Document extends TextInput
         return $this;
     }
 
-    public function cnpj(string|Closure $format = '99.999.999/9999-99'): static
+    public function cnpj(string|Closure $format = '**.***.***/****-99'): static
     {
         $this->dynamic(false)
             ->mask($format);

--- a/src/PtbrCpfCnpj.php
+++ b/src/PtbrCpfCnpj.php
@@ -20,7 +20,7 @@ class PtbrCpfCnpj extends TextInput
     {
         if ($condition) {
             $this->mask(RawJs::make(<<<'JS'
-                $input.length > 14 ? '99.999.999/9999-99' : '999.999.999-99'
+                /[A-Za-z]/.test($input) || $input.replace(/[^A-Za-z0-9]/g, '').length > 11 ? '**.***.***/****-99' : '999.999.999-99'
             JS))->minLength(14);
         }
 
@@ -35,7 +35,7 @@ class PtbrCpfCnpj extends TextInput
         return $this;
     }
 
-    public function cnpj(string|Closure $format = '99.999.999/9999-99'): static
+    public function cnpj(string|Closure $format = '**.***.***/****-99'): static
     {
         $this->dynamic(false)
             ->mask($format);

--- a/tests/DocumentMaskTest.php
+++ b/tests/DocumentMaskTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Filament\Support\RawJs;
+use Illuminate\Support\Facades\Validator;
+use Leandrocfe\FilamentPtbrFormFields\Document;
+
+it('applies the alphanumeric cnpj mask by default', function () {
+    $field = Document::make('cnpj')->cnpj();
+
+    expect((string) $field->getMask())->toBe('**.***.***/****-99');
+});
+
+it('accepts a custom cnpj mask format', function () {
+    $field = Document::make('cnpj')->cnpj('**999999/9999-99');
+
+    expect((string) $field->getMask())->toBe('**999999/9999-99');
+});
+
+it('applies the dynamic alphanumeric mask for cpf or cnpj', function () {
+    $field = Document::make('cpf_or_cnpj')->dynamic();
+
+    $mask = $field->getMask();
+
+    expect($mask)->toBeInstanceOf(RawJs::class)
+        ->and(trim((string) $mask))->toBe(
+            "/[A-Za-z]/.test(\$input) || \$input.replace(/[^A-Za-z0-9]/g, '').length > 11 ? '**.***.***/****-99' : '999.999.999-99'"
+        )
+        ->and($field->getMinLength())->toBe(14);
+});
+
+it('registers the cnpj validation rule', function () {
+    $field = Document::make('cnpj')->cnpj();
+
+    expect($field->getValidationRules())->toContain('cnpj');
+});
+
+it('validates a real alphanumeric cnpj through the registered rule', function () {
+    // Official example from Receita Federal's alphanumeric CNPJ specification.
+    $validator = Validator::make(
+        ['document' => '12ABC34501DE35'],
+        ['document' => 'cnpj']
+    );
+
+    expect($validator->passes())->toBeTrue();
+});
+
+it('fails validation for an alphanumeric cnpj with a wrong check digit', function () {
+    $validator = Validator::make(
+        ['document' => '12ABC34501DE36'],
+        ['document' => 'cnpj']
+    );
+
+    expect($validator->passes())->toBeFalse();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,7 @@ class TestCase extends Orchestra
             \Livewire\LivewireServiceProvider::class,
             \Filament\Support\SupportServiceProvider::class,
             \Filament\Forms\FormsServiceProvider::class,
+            \LaravelLegends\PtBrValidator\ValidatorProvider::class,
             FilamentPtbrFormFieldsServiceProvider::class,
         ];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,12 @@
 
 namespace Leandrocfe\FilamentPtbrFormFields\Tests;
 
+use Filament\Forms\FormsServiceProvider;
+use Filament\Support\SupportServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use LaravelLegends\PtBrValidator\ValidatorProvider;
 use Leandrocfe\FilamentPtbrFormFields\FilamentPtbrFormFieldsServiceProvider;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -20,10 +24,10 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
-            \Livewire\LivewireServiceProvider::class,
-            \Filament\Support\SupportServiceProvider::class,
-            \Filament\Forms\FormsServiceProvider::class,
-            \LaravelLegends\PtBrValidator\ValidatorProvider::class,
+            LivewireServiceProvider::class,
+            SupportServiceProvider::class,
+            FormsServiceProvider::class,
+            ValidatorProvider::class,
             FilamentPtbrFormFieldsServiceProvider::class,
         ];
     }


### PR DESCRIPTION
## Resumo
- Máscara do CNPJ atualizada para o novo padrão alfanumérico da Receita Federal: `**.***.***/****-99` (somente os dígitos verificadores permanecem numéricos).
- Máscara dinâmica (`Document::dynamic()` / `PtbrCpfCnpj::dynamic()`) agora detecta letras ou mais de 11 caracteres para alternar entre CNPJ alfanumérico e CPF.
- A regra de validação `cnpj` (via `laravellegends/pt-br-validator`) já suporta o novo formato sem alterações, confirmado com o exemplo oficial da Receita (`12ABC34501DE35`).

Backport da branch 5.x. Relacionado à discussão #81.

## Test plan
- [x] `composer test` (Pest) — inclui novos testes em `tests/DocumentMaskTest.php` cobrindo máscara padrão, máscara customizada, máscara dinâmica e validação de CNPJ alfanumérico válido/inválido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)