### PR TITLE
fix: use absolute HTTPS URLs for CEP providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The CEP field provides automatic address lookup through configurable providers l
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Set;
 use Leandrocfe\FilamentPtbrFormFields\Cep;
-use Leandrocfe\FilamentPtbrFormFields\CepFieldMode;
+use Leandrocfe\FilamentPtbrFormFields\Enums\CepFieldMode;
 use Leandrocfe\FilamentPtbrFormFields\Providers\ViaCepProvider;
 
 Cep::make('postal_code')
@@ -257,6 +257,33 @@ TextInput::make('neighborhood'),
 TextInput::make('city'),
 TextInput::make('state'),
 ```
+
+#### Configuration
+
+You can publish the configuration file to customize the default API endpoints:
+
+```bash
+php artisan vendor:publish --tag=filament-ptbr-form-fields-config
+```
+
+This will publish `config/filament-ptbr-form-fields.php`:
+
+```php
+return [
+    'viacep_url' => env('VIACEP_URL', 'https://viacep.com.br/ws/'),
+    'brasilapi_url' => env('BRASILAPI_URL', 'https://brasilapi.com.br/api/cep/v1/'),
+];
+```
+
+You can also override the endpoints via environment variables in your `.env` file:
+
+```dotenv
+VIACEP_URL=https://viacep.com.br/ws/
+BRASILAPI_URL=https://brasilapi.com.br/api/cep/v1/
+```
+
+> **Note:** The protocol (`https://`), host, and trailing slash (`/`) are required when specifying custom URLs.
+> If your application uses configuration caching, make sure to run `php artisan config:clear` (or `php artisan config:cache`) after modifying environment variables or the configuration file.
 
 #### Lookup Modes
 
@@ -319,6 +346,27 @@ class MyCustomProvider implements CepProviderInterface
     }
 }
 ```
+
+#### Troubleshooting
+
+##### `URI must include a scheme and host`
+
+If you encounter the following exception when searching for a CEP:
+
+```text
+Illuminate\Http\Client\ConnectionException
+URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.
+```
+
+This occurs when the provider endpoint URL is missing the scheme (e.g., `viacep.com.br/ws/` instead of `https://viacep.com.br/ws/`).
+
+To resolve this:
+1. Ensure your `VIACEP_URL` or `BRASILAPI_URL` environment variables in `.env` include the full protocol: `https://viacep.com.br/ws/` or `https://brasilapi.com.br/api/cep/v1/`.
+2. If you have published `config/filament-ptbr-form-fields.php`, verify that the default URLs include `https://`.
+3. Clear the configuration cache by running:
+   ```bash
+   php artisan config:clear
+   ```
 
 #### Legacy Method (Deprecated)
 

--- a/config/filament-ptbr-form-fields.php
+++ b/config/filament-ptbr-form-fields.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'viacep_url' => env('VIACEP_URL', 'viacep.com.br/ws/'),
-    'brasilapi_url' => env('BRASILAPI_URL', 'brasilapi.com.br/api/cep/v1/'),
+    'viacep_url' => env('VIACEP_URL', 'https://viacep.com.br/ws/'),
+    'brasilapi_url' => env('BRASILAPI_URL', 'https://brasilapi.com.br/api/cep/v1/'),
 ];

--- a/src/Concerns/HasCepModes.php
+++ b/src/Concerns/HasCepModes.php
@@ -6,6 +6,7 @@ use Filament\Actions\Action;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Collection;
 use Leandrocfe\FilamentPtbrFormFields\Enums\CepFieldMode;
 use Leandrocfe\FilamentPtbrFormFields\Providers\CepProviderInterface;
 use Livewire\Component;
@@ -72,7 +73,7 @@ trait HasCepModes
             });
     }
 
-    protected function fetchCepData(?string $cep, CepProviderInterface $provider): null|array|\Illuminate\Support\Collection
+    protected function fetchCepData(?string $cep, CepProviderInterface $provider): null|array|Collection
     {
         if (blank($cep)) {
             return null;

--- a/src/PtbrCep.php
+++ b/src/PtbrCep.php
@@ -22,7 +22,7 @@ class PtbrCep extends TextInput
 
             $livewire->validateOnly($component->getKey());
 
-            $request = Http::get("viacep.com.br/ws/$state/json/")->json();
+            $request = Http::get("https://viacep.com.br/ws/$state/json/")->json();
 
             foreach ($setFields as $key => $value) {
                 $set($key, $request[$value] ?? null);

--- a/tests/BrasilApiProviderTest.php
+++ b/tests/BrasilApiProviderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Leandrocfe\FilamentPtbrFormFields\Providers\BrasilApiProvider;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('fetches address data using default brasilapi configuration', function () {
+    $expectedData = [
+        'cep' => '01001000',
+        'state' => 'SP',
+        'city' => 'São Paulo',
+        'neighborhood' => 'Sé',
+        'street' => 'Praça da Sé',
+        'service' => 'viacep',
+    ];
+
+    Http::fake([
+        'https://brasilapi.com.br/api/cep/v1/01001000' => Http::response($expectedData, 200),
+    ]);
+
+    $provider = new BrasilApiProvider;
+    $response = $provider->fetch('01001000');
+
+    expect($response)->toBe($expectedData);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://brasilapi.com.br/api/cep/v1/01001000';
+    });
+});
+
+it('returns null when brasilapi returns error payload', function () {
+    Http::fake([
+        'https://brasilapi.com.br/api/cep/v1/99999999' => Http::response([
+            'name' => 'CepPromiseError',
+            'message' => 'CEP não encontrado na base do BrasilAPI',
+            'type' => 'service_error',
+            'error' => 'not_found',
+        ], 404),
+    ]);
+
+    $provider = new BrasilApiProvider;
+    $response = $provider->fetch('99999999');
+
+    expect($response)->toBeNull();
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://brasilapi.com.br/api/cep/v1/99999999';
+    });
+});
+
+it('returns null when brasilapi returns empty response', function () {
+    Http::fake([
+        'https://brasilapi.com.br/api/cep/v1/00000000' => Http::response([], 200),
+    ]);
+
+    $provider = new BrasilApiProvider;
+    $response = $provider->fetch('00000000');
+
+    expect($response)->toBeNull();
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://brasilapi.com.br/api/cep/v1/00000000';
+    });
+});
+
+it('fetches address data using custom url passed to constructor', function () {
+    $expectedData = [
+        'cep' => '01001000',
+        'state' => 'SP',
+        'city' => 'São Paulo',
+    ];
+
+    Http::fake([
+        'https://custom-brasilapi.test/api/cep/v1/01001000' => Http::response($expectedData, 200),
+    ]);
+
+    $provider = new BrasilApiProvider('https://custom-brasilapi.test/api/cep/v1/');
+    $response = $provider->fetch('01001000');
+
+    expect($response)->toBe($expectedData);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://custom-brasilapi.test/api/cep/v1/01001000';
+    });
+});
+
+it('fetches address data using overridden config brasilapi_url', function () {
+    config()->set('filament-ptbr-form-fields.brasilapi_url', 'https://custom-config-brasilapi.test/api/cep/v1/');
+
+    $expectedData = [
+        'cep' => '01001000',
+        'state' => 'SP',
+        'city' => 'São Paulo',
+    ];
+
+    Http::fake([
+        'https://custom-config-brasilapi.test/api/cep/v1/01001000' => Http::response($expectedData, 200),
+    ]);
+
+    $provider = new BrasilApiProvider;
+    $response = $provider->fetch('01001000');
+
+    expect($response)->toBe($expectedData);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://custom-config-brasilapi.test/api/cep/v1/01001000';
+    });
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,11 @@
 
 namespace Leandrocfe\FilamentPtbrFormFields\Tests;
 
+use Filament\Forms\FormsServiceProvider;
+use Filament\Support\SupportServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Leandrocfe\FilamentPtbrFormFields\FilamentPtbrFormFieldsServiceProvider;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -20,9 +23,9 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
-            \Livewire\LivewireServiceProvider::class,
-            \Filament\Support\SupportServiceProvider::class,
-            \Filament\Forms\FormsServiceProvider::class,
+            LivewireServiceProvider::class,
+            SupportServiceProvider::class,
+            FormsServiceProvider::class,
             FilamentPtbrFormFieldsServiceProvider::class,
         ];
     }

--- a/tests/ViaCepProviderTest.php
+++ b/tests/ViaCepProviderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Leandrocfe\FilamentPtbrFormFields\Providers\ViaCepProvider;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('fetches address data using default viacep configuration', function () {
+    $expectedData = [
+        'cep' => '01001-000',
+        'logradouro' => 'Praça da Sé',
+        'complemento' => 'lado ímpar',
+        'bairro' => 'Sé',
+        'localidade' => 'São Paulo',
+        'uf' => 'SP',
+        'ibge' => '3550308',
+        'gia' => '1004',
+        'ddd' => '11',
+        'siafi' => '7107',
+    ];
+
+    Http::fake([
+        'https://viacep.com.br/ws/01001000/json/' => Http::response($expectedData, 200),
+    ]);
+
+    $provider = new ViaCepProvider;
+    $response = $provider->fetch('01001000');
+
+    expect($response)->toBe($expectedData);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://viacep.com.br/ws/01001000/json/';
+    });
+});
+
+it('returns null when viacep returns erro payload', function () {
+    Http::fake([
+        'https://viacep.com.br/ws/99999999/json/' => Http::response(['erro' => 'true'], 200),
+    ]);
+
+    $provider = new ViaCepProvider;
+    $response = $provider->fetch('99999999');
+
+    expect($response)->toBeNull();
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://viacep.com.br/ws/99999999/json/';
+    });
+});
+
+it('returns null when viacep returns empty response', function () {
+    Http::fake([
+        'https://viacep.com.br/ws/00000000/json/' => Http::response([], 200),
+    ]);
+
+    $provider = new ViaCepProvider;
+    $response = $provider->fetch('00000000');
+
+    expect($response)->toBeNull();
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://viacep.com.br/ws/00000000/json/';
+    });
+});
+
+it('fetches address data using custom url passed to constructor', function () {
+    $expectedData = [
+        'cep' => '01001-000',
+        'logradouro' => 'Praça da Sé',
+    ];
+
+    Http::fake([
+        'https://custom-viacep.test/ws/01001000/json/' => Http::response($expectedData, 200),
+    ]);
+
+    $provider = new ViaCepProvider('https://custom-viacep.test/ws/');
+    $response = $provider->fetch('01001000');
+
+    expect($response)->toBe($expectedData);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://custom-viacep.test/ws/01001000/json/';
+    });
+});
+
+it('fetches address data using overridden config viacep_url', function () {
+    config()->set('filament-ptbr-form-fields.viacep_url', 'https://custom-config-viacep.test/ws/');
+
+    $expectedData = [
+        'cep' => '01001-000',
+        'logradouro' => 'Praça da Sé',
+    ];
+
+    Http::fake([
+        'https://custom-config-viacep.test/ws/01001000/json/' => Http::response($expectedData, 200),
+    ]);
+
+    $provider = new ViaCepProvider;
+    $response = $provider->fetch('01001000');
+
+    expect($response)->toBe($expectedData);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://custom-config-viacep.test/ws/01001000/json/';
+    });
+});


### PR DESCRIPTION
## Description

This PR fixes an `Illuminate\Http\Client\ConnectionException` thrown when performing CEP searches via `ViaCepProvider` or `BrasilApiProvider`.

### Root Cause
In `config/filament-ptbr-form-fields.php`, default provider endpoints were defined without the URI scheme (`viacep.com.br/ws/` and `brasilapi.com.br/api/cep/v1/`). `ViaCepProvider` and `BrasilApiProvider` concatenate the CEP directly to these configured values and pass them to `Http::get()`. Because no scheme or `base_uri` was present, Laravel/Guzzle threw:
```text
Illuminate\Http\Client\ConnectionException: URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.
```

### Changes
1. **Absolute HTTPS URLs by default**:
   - `viacep_url`: `https://viacep.com.br/ws/`
   - `brasilapi_url`: `https://brasilapi.com.br/api/cep/v1/`
   - Fixed legacy `PtbrCep` helper to also use absolute `https://viacep.com.br/ws/` endpoint.
2. **Regression Tests**:
   - Added unit tests for `ViaCepProvider` and `BrasilApiProvider` covering default URLs, constructor override, config override, empty response, and error payloads using `Http::fake()` and `Http::preventStrayRequests()`.
3. **Documentation**:
   - Fixed `CepFieldMode` import namespace (`Leandrocfe\FilamentPtbrFormFields\Enums\CepFieldMode`).
   - Documented how to publish configuration (`php artisan vendor:publish --tag=filament-ptbr-form-fields-config`).
   - Documented `.env` overrides (`VIACEP_URL`, `BRASILAPI_URL`) noting that protocol and trailing slash are required.
   - Added troubleshooting section for `URI must include a scheme and host`.

### Impact on Published Configurations
Applications that previously published `config/filament-ptbr-form-fields.php` with schemeless URLs (`viacep.com.br/ws/` or `brasilapi.com.br/api/cep/v1/`) will need to update their published config file or set `VIACEP_URL` / `BRASILAPI_URL` with `https://` in `.env` and clear their config cache (`php artisan config:clear`).

### Test Results
- `composer validate --strict` -> Valid
- `composer format` -> Pint passed
- `composer test` -> 12 passed (24 assertions)
- `composer analyse` -> PHPStan passed with 0 errors